### PR TITLE
Fix application/Makefile for FuzzySearch

### DIFF
--- a/applications/Makefile
+++ b/applications/Makefile
@@ -345,7 +345,7 @@ fuzzysearch:
 	  --locale=$(LOCALE) \
 	  $(shell $(PERL) -e 'print $(FUZZY_NORMALIZE_WORDS) ? "--normalize" : "";') \
 	  $(shell $(PERL) -e 'print $(FUZZY_SEARCH_ALGORITHM) eq "simple" ? "-T" : "";') \
-	  $(DB_PREFIX).
+	  $(DB_PREFIX)
 
 # Get CSV file from https://ad-research.cs.uni-freiburg.de (for example
 # applications). If the file already exists, will not download it again.


### PR DESCRIPTION
When building the data for fuzzysearch [WordClusteringBuilder.cpp](https://github.com/ad-freiburg/completesearch/blob/561b527735ee45ed5bda526949b6a8e096838526/src/fuzzysearch/WordClusteringBuilder.cpp#L132) tries to open the `.vocabulary+frequencies` file with one `.` to many. For example `mails..vocabulary+frequencies` instead of `mails.vocabulary+frequencies`.
https://github.com/ad-freiburg/completesearch/blob/561b527735ee45ed5bda526949b6a8e096838526/src/fuzzysearch/WordClusteringBuilder.cpp#L132

This is caused by a redundant `.` in [application/Makefile](https://github.com/ad-freiburg/completesearch/blob/561b527735ee45ed5bda526949b6a8e096838526/applications/Makefile#L348) which through [BuildFuzzySearchClusters.cpp](https://github.com/ad-freiburg/completesearch/blob/master/src/fuzzysearch/BuildFuzzySearchClusters.cpp) lands in [WordClusteringBuilder.cpp](https://github.com/ad-freiburg/completesearch/blob/561b527735ee45ed5bda526949b6a8e096838526/src/fuzzysearch/WordClusteringBuilder.cpp#L132): https://github.com/ad-freiburg/completesearch/blob/561b527735ee45ed5bda526949b6a8e096838526/applications/Makefile#L348

This PR fixes that.