### PR TITLE
Fix out of Bounds Read in StringConverter::replaceNonAlphanum

### DIFF
--- a/src/utility/StringConverter.cpp
+++ b/src/utility/StringConverter.cpp
@@ -458,7 +458,8 @@ string StringConverter::replaceNonAlphanum(const string&         sIn,
       }
       string sUtf8Char = getUtf8Encoding(nCp);
 
-      if (nCp <= MAX_UTF8_CODEPOINT && (bInSaveList == true || _isAlphanumCodepointUtf8[nCp] == true))
+      if (bInSaveList == true || (nCp <= MAX_UTF8_CODEPOINT &&
+          _isAlphanumCodepointUtf8[nCp] == true))
       {
         sRes += sUtf8Char;
       }
@@ -492,7 +493,8 @@ string StringConverter::replaceNonAlphanum(const string&         sIn,
           bInSaveList = true;
         }
       }
-      if (nCp <= MAX_ISO_CODEPOINT && (bInSaveList == true || _isAlphanumCodepointIso8859_1[nCp] == true))
+      if (bInSaveList == true || (nCp <= MAX_ISO_CODEPOINT &&
+          _isAlphanumCodepointIso8859_1[nCp] == true))
       {
         sRes[m++] =  static_cast<char>(nCp);
       }

--- a/src/utility/StringConverter.cpp
+++ b/src/utility/StringConverter.cpp
@@ -458,8 +458,7 @@ string StringConverter::replaceNonAlphanum(const string&         sIn,
       }
       string sUtf8Char = getUtf8Encoding(nCp);
 
-      if ((bInSaveList == true || _isAlphanumCodepointUtf8[nCp] == true)
-          && nCp <= MAX_UTF8_CODEPOINT)
+      if (nCp <= MAX_UTF8_CODEPOINT && (bInSaveList == true || _isAlphanumCodepointUtf8[nCp] == true))
       {
         sRes += sUtf8Char;
       }
@@ -493,8 +492,7 @@ string StringConverter::replaceNonAlphanum(const string&         sIn,
           bInSaveList = true;
         }
       }
-      if ((bInSaveList == true || _isAlphanumCodepointIso8859_1[nCp] == true)
-          && nCp <= MAX_ISO_CODEPOINT)
+      if (nCp <= MAX_ISO_CODEPOINT && (bInSaveList == true || _isAlphanumCodepointIso8859_1[nCp] == true))
       {
         sRes[m++] =  static_cast<char>(nCp);
       }


### PR DESCRIPTION
The check whether a char is a UTF8/ISO Code point is done after the check whether it is a wanted codepoint. Because the second check is done via a bool vector lookup this causes an out of bound read.