### PR TITLE
Fix `stop` target in `applications/Makefile`

### DIFF
--- a/applications/Makefile
+++ b/applications/Makefile
@@ -137,7 +137,8 @@ start::
 	$(MAKE) $(DB_PREFIX).start
 
 stop::
-	$(CS_BIN_DIR)/startCompletionServer --kill $(PORT)
+	$(CS_BIN_DIR)/startCompletionServer --pid-file=$(PID_FILE_FORMAT) \
+	  --kill $(PORT)
 
 log:
 	tail -n 200 -f $(DB_PREFIX).log


### PR DESCRIPTION
The start rule in applications/Makefile uses a custom path for the PID file. This has the effect that the PID file resides in the data directory. By default, the file resides in the user's home directory. The stop rule didn't use this custom path and thus fell back to the default path. This meant that the server couldn't be stopped correctly.